### PR TITLE
del MVP 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ Download & Install del from source repo
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SathvikPN/del/main/del_install.sh | sudo bash
 ```
+
+# Usage
+```bash
+sathvikpn:~/workspace/del$ ./del.sh --help
+Usage: del [OPTIONS] FILE...
+
+Options:
+    -h, --help      Show this help message and exit
+    -v, --verbose   Show the actions performed
+        --version   Show version information
+        --config    Update configuration file
+        --reset     Reset config file to defaults
+        --cleanup   Clear files older than configured days
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # del
-A recycle bin utility for your Linux bash terminal
+A recycle bin utility for your Linux bash terminal.
 
-- trash files into trash-directory
-- recover files from trash-directory
-- periodic auto deletes file from trash-directory
+- `del` moves files to a trash can instead of permanently deleting them, allowing you to recover accidentally deleted files from bash terminal. 
+- `del` also includes metadata about deleted files, when, where and by whom it was deleted. 
+- `del` has an automatic cleanup feature to manage your trash can efficiently.
+- `del` is configurable to set number of days to keep deleted files and schedule day in a month to run this automatically.
+
+> del is an wrapper around `mv` `rm` and `crontab`
+
+
+# Installation
+Download & Install del from source repo
+```bash
+curl -fsSL https://raw.githubusercontent.com/SathvikPN/del/main/del_install.sh | sudo bash
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A recycle bin utility for your Linux bash terminal.
 - `del` moves files to a trash can instead of permanently deleting them, allowing you to recover accidentally deleted files from bash terminal. 
 - `del` also includes metadata about deleted files, when, where and by whom it was deleted. 
 - `del` has an automatic cleanup feature to manage your trash can efficiently.
-- `del` is configurable to set number of days to keep deleted files and schedule day in a month to run this automatically.
+- `del` is configurable to set number of days to keep deleted files and schedule day in a month to run cleanup automatically.
 
 > del is an wrapper around `mv` `rm` and `crontab`
 
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/SathvikPN/del/main/del_install.sh |
 
 # Usage
 ```bash
-sathvikpn:~/workspace/del$ ./del.sh --help
+sathvikpn:~/workspace/$ del --help
 Usage: del [OPTIONS] FILE...
 
 Options:

--- a/del.sh
+++ b/del.sh
@@ -2,6 +2,7 @@
 
 VERSION=1.0.0
 AUTHOR=sathvikpn
+SOURCE='https://github.com/SathvikPN/del'
 
 # default configs 
 VERBOSE=0
@@ -39,8 +40,9 @@ EOF
 
 # Function to show version
 show_version() {
-    echo "del version $VERSION"
-    echo "author: $AUTHOR"
+    echo "version: del $VERSION"
+    echo " author: $AUTHOR"
+    echo " source: $SOURCE"
 }
 
 edit_config() {

--- a/del.sh
+++ b/del.sh
@@ -49,6 +49,26 @@ edit_config() {
     source "$CONFIG_FILE"
 }
 
+move_to_trash() {
+    local src="$1"
+    local filename=$(basename "$src")
+    local dest="${TRASH_DIR}/${filename}"
+    local metadata="${TRASH_DIR}/${filename}.delInfo"
+
+    # Verbose output
+    if [[ $VERBOSE -eq 1 ]]; then
+        echo "trashing '$filename' to '$dest'"
+    fi
+
+    # Move the file
+    mv "$src" "$dest"
+
+    # Create metadata file
+    echo "deletedFrom: $(realpath "$src")" > "$metadata"
+    echo "deletedOn: $(date '+%Y-%m-%d %H:%M:%S')" >> "$metadata"
+    echo "deletedBy: $USER" >> "$metadata"
+}
+
 
 
 
@@ -84,3 +104,11 @@ if [[ $# -eq 0 ]]; then
     show_help
     exit 1
 fi
+
+for file in "$@"; do
+    if [[ -e "$file" ]]; then
+        move_to_trash "$file"
+    else
+        echo "Error: not found '$file'"
+    fi
+done

--- a/del.sh
+++ b/del.sh
@@ -3,8 +3,27 @@
 VERSION=1.0.0
 AUTHOR=sathvikpn
 
-# default configs
+# default configs 
 VERBOSE=0
+CONFIG_FILE="${HOME}/.delconfig"
+DEFAULT_TRASH_DIR="${HOME}/.local/share/Trash/files"
+DEFAULT_AUTO_PURGE_DAYS=30
+CRON_JOB_ID="del_cleanup"
+
+create_default_config() {
+cat <<EOF > "$CONFIG_FILE"
+TRASH_DIR="${DEFAULT_TRASH_DIR}"
+AUTO_PURGE_DAYS=${DEFAULT_AUTO_PURGE_DAYS}
+EOF
+}
+
+del_init(){
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        create_default_config
+    fi
+    source "$CONFIG_FILE"
+    mkdir -p $TRASH_DIR
+}
 
 show_help() {
 cat << EOF
@@ -24,7 +43,21 @@ show_version() {
     echo "author: $AUTHOR"
 }
 
+edit_config() {
+    ${EDITOR:-vi} "$CONFIG_FILE"
+    # Reload configuration after editing
+    source "$CONFIG_FILE"
+}
+
+
+
+
+
+
+
 # script starts here ----------------------------------------------------------
+
+del_init
 
 # parse args
 case "$1" in
@@ -41,6 +74,7 @@ case "$1" in
         exit 0
         ;;
     --config)
+        edit_config
         exit 0
         ;;
 esac

--- a/del.sh
+++ b/del.sh
@@ -72,6 +72,20 @@ move_to_trash() {
 }
 
 
+# manage cron job for periodic cleanup
+manage_auto_cleanup() {
+    local cron_cmd="0 0 ${AUTO_PURGE_DAYS} * * /usr/local/bin/del --cleanup # $CRON_JOB_ID"
+    local cron_exists=$(crontab -l 2>/dev/null | grep -F "$CRON_JOB_ID")
+
+    if [[ -z "$cron_exists" ]]; then
+        # Cron job does not exist, create it
+        (crontab -l 2>/dev/null; echo "$cron_cmd") | crontab -
+        echo "created cron job for periodic cleanup."
+    else 
+        crontab -l 2>/dev/null | grep -v "$CRON_JOB_ID" | { cat; echo "$cron_cmd"; } | crontab -
+        echo "updated cron job for periodic cleanup."
+    fi
+}
 
 
 
@@ -97,6 +111,7 @@ case "$1" in
         ;;
     --config)
         edit_config
+        manage_auto_cleanup
         exit 0
         ;;
 esac
@@ -114,3 +129,5 @@ for file in "$@"; do
         echo "Error: not found '$file'"
     fi
 done
+
+manage_auto_cleanup

--- a/del.sh
+++ b/del.sh
@@ -73,13 +73,13 @@ move_to_trash() {
     local dest="${TRASH_DIR}/${filename}"
     local metadata="${TRASH_DIR}/${filename}.delInfo"
 
-    # Verbose output
-    if [[ $VERBOSE -eq 1 ]]; then
-        echo "trashing '$filename' to '$dest'"
-    fi
-
     # Move the file
     mv "$src" "$dest"
+
+    # Verbose output
+    if [[ $VERBOSE -eq 1 ]]; then
+        echo "trashed '$filename' to '$dest'"
+    fi
 
     # Create metadata file
     echo "deletedFrom: $(realpath "$src")" > "$metadata"

--- a/del.sh
+++ b/del.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+VERSION=1.0.0
+AUTHOR=sathvikpn
+
+# default configs
+VERBOSE=0
+
+show_help() {
+cat << EOF
+Usage: del [OPTIONS] FILE...
+
+Options:
+    -h, --help      Show this help message and exit
+    -v, --verbose   Show the actions performed
+        --version   Show version information
+        --config    Update configuration file
+EOF
+}
+
+# Function to show version
+show_version() {
+    echo "del version $VERSION"
+    echo "author: $AUTHOR"
+}
+
+# script starts here ----------------------------------------------------------
+
+# parse args
+case "$1" in
+    -h|--help)
+        show_help
+        exit 0
+        ;;
+    -v|--verbose)
+        VERBOSE=1
+        shift
+        ;;
+    --version)
+        show_version
+        exit 0
+        ;;
+    --config)
+        exit 0
+        ;;
+esac
+
+if [[ $# -eq 0 ]]; then
+    echo "del: no files specified."
+    show_help
+    exit 1
+fi

--- a/del.sh
+++ b/del.sh
@@ -4,13 +4,13 @@ VERSION=1.0.0
 AUTHOR=sathvikpn
 SOURCE='https://github.com/SathvikPN/del'
 
+CRON_JOB_ID="del_cleanup"
+
 # default configs 
 VERBOSE=0
-RESET=0
 CONFIG_FILE="${HOME}/.delconfig"
 DEFAULT_TRASH_DIR="${HOME}/.local/share/Trash/files"
 DEFAULT_AUTO_PURGE_DAYS=30
-CRON_JOB_ID="del_cleanup"
 
 create_default_config() {
 cat <<EOF > "$CONFIG_FILE"
@@ -155,5 +155,3 @@ for file in "$@"; do
         echo "Error: not found '$file'"
     fi
 done
-
-manage_auto_cleanup

--- a/del.sh
+++ b/del.sh
@@ -6,6 +6,7 @@ SOURCE='https://github.com/SathvikPN/del'
 
 # default configs 
 VERBOSE=0
+RESET=0
 CONFIG_FILE="${HOME}/.delconfig"
 DEFAULT_TRASH_DIR="${HOME}/.local/share/Trash/files"
 DEFAULT_AUTO_PURGE_DAYS=30
@@ -35,6 +36,7 @@ Options:
     -v, --verbose   Show the actions performed
         --version   Show version information
         --config    Update configuration file
+        --reset     Reset config file to defaults
 EOF
 }
 
@@ -80,14 +82,18 @@ manage_auto_cleanup() {
     if [[ -z "$cron_exists" ]]; then
         # Cron job does not exist, create it
         (crontab -l 2>/dev/null; echo "$cron_cmd") | crontab -
-        echo "created cron job for periodic cleanup."
     else 
         crontab -l 2>/dev/null | grep -v "$CRON_JOB_ID" | { cat; echo "$cron_cmd"; } | crontab -
-        echo "updated cron job for periodic cleanup."
     fi
+
+    echo "del: set auto delete interval [$AUTO_PURGE_DAYS days]"
 }
 
-
+del_reset() {
+    rm -f $CONFIG_FILE
+    del_init
+    echo "del: reset to default completed"
+}
 
 
 
@@ -112,6 +118,10 @@ case "$1" in
     --config)
         edit_config
         manage_auto_cleanup
+        exit 0
+        ;;
+    --reset)
+        del_reset
         exit 0
         ;;
 esac

--- a/del.sh
+++ b/del.sh
@@ -37,6 +37,7 @@ Options:
         --version   Show version information
         --config    Update configuration file
         --reset     Reset config file to defaults
+        --cleanup   Clear files older than configured days
 EOF
 }
 
@@ -71,6 +72,17 @@ move_to_trash() {
     echo "deletedFrom: $(realpath "$src")" > "$metadata"
     echo "deletedOn: $(date '+%Y-%m-%d %H:%M:%S')" >> "$metadata"
     echo "deletedBy: $USER" >> "$metadata"
+}
+
+# cleanup old files
+cleanup_old_files() {
+    find "$TRASH_DIR" -type f -name "*.delInfo" -mtime +"$AUTO_PURGE_DAYS" -print0 | while IFS= read -r -d '' metadata; do
+        local file="${metadata%.delInfo}"
+        rm -f "$file" "$metadata"
+        if [[ $VERBOSE -eq 1 ]]; then
+            echo "del: permanently deleted '$file' and metadata '$metadata'"
+        fi
+    done
 }
 
 
@@ -122,6 +134,10 @@ case "$1" in
         ;;
     --reset)
         del_reset
+        exit 0
+        ;;
+    --cleanup)
+        cleanup_old_files
         exit 0
         ;;
 esac

--- a/del_install.sh
+++ b/del_install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Download and install del from source repo
+curl -o /usr/local/bin/del https://raw.githubusercontent.com/SathvikPN/del/main/del.sh \
+  && chmod +x /usr/local/bin/del \
+  && echo "del installed successfully."


### PR DESCRIPTION
# del
A recycle bin utility for your Linux bash terminal.

- `del` moves files to a trash can instead of permanently deleting them, allowing you to recover accidentally deleted files from bash terminal. 
- `del` also includes metadata about deleted files, when, where and by whom it was deleted. 
- `del` has an automatic cleanup feature to manage your trash can efficiently.
- `del` is configurable to set number of days to keep deleted files and schedule day in a month to run this automatically.

> del is an wrapper around `mv` `rm` and `crontab`

```bash
sathvikpn:~/workspace/del$ ./del.sh --help
Usage: del [OPTIONS] FILE...

Options:
    -h, --help      Show this help message and exit
    -v, --verbose   Show the actions performed
        --version   Show version information
        --config    Update configuration file
        --reset     Reset config file to defaults
        --cleanup   Clear files older than configured days
```